### PR TITLE
separator option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (ps, _JSON, opts) {
   var separator = opts.separator || '\n'
   return {
     sink: pull(
-      splitter(split),
+      splitter(separator),
       pull.map(function(data) {
         try { return _JSON.parse(data) }
         catch (e) {


### PR DESCRIPTION
this allows the user to pass in a different string for the separator.
for example, `\n\n`, a good choice because then you get the advantage of easy parsing,
but also use pretty printing and get human readability too!
