### PR TITLE
let pull.map handle errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ module.exports = function (ps, _JSON, opts) {
       pull.map(function(data) {
         try { return _JSON.parse(data) }
         catch (e) {
-          if (!opts.ignoreErrors)
-            return e
+          if (!opts.ignoreErrors) throw e
         }
       }),
       pull.filter(),


### PR DESCRIPTION
This changes how the error handling works, so that errors abort the stream.
Usually, a parse error is due to a programmer error, so that is probably what you want.

Or maybe you want to ignore the incorrect lines, but probably downstream can't do anything about the syntax errors so adding them to the stream just means they get ignored downstream, simpler to ignore them here.
