### PR TITLE
Playing around with tape test output

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "pull-stream": "~2.26.0"
   },
   "devDependencies": {
+    "faucet": "0.0.1",
     "tape": "~3.0.0"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape test/*.js | faucet"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"

--- a/test/json.js
+++ b/test/json.js
@@ -7,7 +7,6 @@ tape('JSON', function (t) {
   var theDuplex = serializer({
     source: pull.values([5, "foo", [1,2,3], {hello: 'world'}]),
     sink: pull.collect(function(err, values) {
-      console.log(values)
       if (err) throw err
       t.equal(values[0], 5)
       t.equal(values[1], "foo")
@@ -20,7 +19,6 @@ tape('JSON', function (t) {
   pull(
     theDuplex,
     pull.map(function(str) {
-      console.log(typeof str, str)
       t.assert(typeof str == 'string')
       return str
     }),
@@ -33,7 +31,6 @@ tape('chunky', function (t) {
   var theDuplex = serializer({
     source: pull.values([55, "foo", [1,2,3], {hello: 'world'}]),
     sink: pull.collect(function(err, values) {
-      console.log(values)
       if (err) throw err
       t.equal(values[0], 55)
       t.equal(values[1], "foo")
@@ -70,7 +67,6 @@ tape('parse errors', function (t) {
   var theDuplex = serializer({
     source: pull.values(['test']),
     sink: pull.collect(function(err, values) {
-      console.log(err, values)
       t.equal(!!err, true)
       t.equal(values.length, 0)
       t.end()
@@ -96,7 +92,6 @@ tape('error suppression', function (t) {
   var theDuplex = serializer({
     source: pull.values(['fail', 'success']),
     sink: pull.collect(function(err, values) {
-      console.log(values)
       if (err) throw err
       t.equal(values[0], 'success')
       t.end()


### PR DESCRIPTION
We all know that testing is important and we want information when something fails. But we don't really care about the details when something just works. I wanted to try out `faucet` by @substack to explore test output a bit.

What do you think?

Before change:

```
$ t

> pull-serializer@0.3.2 test /home/lms/src/ssbc/pull-serializer
> set -e; for t in test/*.js; do node $t; done

TAP version 13
# JSON
string 5

ok 1 (unnamed assert)
string "foo"

ok 2 (unnamed assert)
string [1,2,3]

ok 3 (unnamed assert)
string {"hello":"world"}

ok 4 (unnamed assert)
[ 5, 'foo', [ 1, 2, 3 ], { hello: 'world' } ]
ok 5 should be equal
ok 6 should be equal
ok 7 should be equal
ok 8 should be equal
# chunky
[ 55, 'foo', [ 1, 2, 3 ], { hello: 'world' } ]
ok 9 should be equal
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
# parse errors
[SyntaxError: Unexpected end of input] []
ok 13 should be equal
ok 14 should be equal
# error suppression
[ 'success' ]
ok 15 should be equal

1..15
# tests 15
# pass  15

# ok
```

After change:

```
$ t

> pull-serializer@0.3.2 test /home/lms/src/ssbc/pull-serializer
> tape test/*.js | faucet

✓ JSON
✓ chunky
✓ parse errors
✓ error suppression
# tests 15
# pass  15
✓ ok
```

Error output (obviously a simulation):

```
$ t

> pull-serializer@0.3.2 test /home/lms/src/ssbc/pull-serializer
> tape test/*.js | faucet

✓ JSON
✓ chunky
⨯ parse errors
  not ok 13 should be equal
    ---
      operator: equal
      expected: false
      actual:   true
      at: serializer.sink (/home/lms/src/ssbc/pull-serializer/test/json.js:70:9)
    ...
✓ error suppression
# tests 15
# pass  14
⨯ fail  1
npm ERR! Test failed.  See above for more details.
```
